### PR TITLE
Dialog: transition events

### DIFF
--- a/packages/documentation/src/guide/components/dialog.md
+++ b/packages/documentation/src/guide/components/dialog.md
@@ -22,10 +22,10 @@ A Dialog component is a modal window that can be used to display information or 
 | `title`                   | A title for the dialog                         | `String`                                  | `undefined` |
 | `teleport`                | If we should teleport the dropdown             | `Boolean`                                 | `true`      |
 | `teleportTo`              | Element to teleport                            | `string`                                  | `body`      |
-| `closeableOnClickOutside` | Clicking outside closes the slideover          | `Boolean`                                 | `true`      |
-| `overlay`                 | Adds a overlay behind the slideover            | `Boolean`                                 | `true`      |
-| `closeable`               | If we should allow open/close the slideover    | `Boolean`                                 | `true`      |
-| `closeableOnPressEscape`  | Keyboard ESC closes the slideover              | `Boolean`                                 | `true`      |
+| `closeableOnClickOutside` | Clicking outside closes the dialog             | `Boolean`                                 | `true`      |
+| `overlay`                 | Adds a overlay behind the dialog               | `Boolean`                                 | `true`      |
+| `closeable`               | If we should allow open/close the dialog       | `Boolean`                                 | `true`      |
+| `closeableOnPressEscape`  | Keyboard ESC closes the dialog                 | `Boolean`                                 | `true`      |
 | `paddingOnModal`          | Give padding to the whole modal                | `Boolean`                                 | `true`      |
 | `bodyDivided`             | Divide the items inside the body               | `Boolean`                                 | `false`     |
 | `bodyDarker`              | Darkens the modal body, for easier reading     | `Boolean`                                 | `false`     |
@@ -57,11 +57,15 @@ Footer part of the modal, usually used to place buttons or actions.
 | Event   | Description             | Value     |
 |:--------|:------------------------|:----------|
 !!!include(./src/parts/events-model-value.md)!!!
-| `open` | Slideover was opened | `Boolean` |
-| `close` | Slideover was closed | `Boolean` |
+| `open` | Dialog was opened | `Boolean` |
+| `close` | Dialog was closed | `Boolean` |
+| `opening` | Dialog is about to be opened — before the transition starts | `Boolean` |
+| `opened` | Dialog was opened — after the transition finishes | `Boolean` |
+| `closing` | Dialog is about to be closed — before the transition starts | `Boolean` |
+| `closed` | Dialog was closed — after the transition finishes | `Boolean` |
 
 :::warning :bulb: A note on closing and open
-The `open` and `close` events are emitted when the slideover is opened or closed, but the `modelValue` is not updated yet.
+The `open` and `close` events are emitted when the dialog is opened or closed, but the `modelValue` is not updated yet.
 It will take a few milliseconds in order to circumvent the `transition` effect and provide a smooth experience.
 :::
 

--- a/packages/vanilla-components/src/components/dialog/dialog.vue
+++ b/packages/vanilla-components/src/components/dialog/dialog.vue
@@ -90,6 +90,10 @@ const emit = defineEmits([
   'update:modelValue',
   'close',
   'open',
+  'opening',
+  'opened',
+  'closing',
+  'closed',
 ])
 
 const localValue = useVModel(props, 'modelValue')
@@ -116,6 +120,8 @@ const open = () => {
   emit('open')
 }
 
+const emitTransitionEvent = (event: 'opening' | 'opened' | 'closing' | 'closed') => emit(event)
+
 provide('configuration_vanilla', configuration)
 
 defineOptions({
@@ -128,6 +134,10 @@ defineOptions({
     appear
     :show="localValue"
     as="template"
+    @before-enter="emitTransitionEvent('opening')"
+    @after-enter="emitTransitionEvent('opened')"
+    @before-leave="emitTransitionEvent('closing')"
+    @after-leave="emitTransitionEvent('closed')"
   >
     <HeadlessDialog
       :as="as"


### PR DESCRIPTION
This PR adds 4 useful events on the dialog component: opening, opened, closing, closed. These events are useful when we want to lazy load some data on the dialog, redirect after the dialog has closed, etc. I'm sure there are tons of use cases.

Recap:
* Added opening, opened, closing, closed events
* Added documentation for them
* Replaced "slideover" with "dialog" - I'm sure this part was copied from the slideover component and you forgot to replace it :sweat_smile:

Cheers.

P.S If PR is approved I will add the same events for slideover and PR again.