### PR TITLE
Slideover: transition events

### DIFF
--- a/packages/documentation/src/guide/components/slideover.md
+++ b/packages/documentation/src/guide/components/slideover.md
@@ -73,6 +73,10 @@ Slot to override the close icon on the top right corner of the slideover
 !!!include(./src/parts/events-model-value.md)!!!
 | `open` | Slideover was opened | `Boolean` |
 | `close` | Slideover was closed | `Boolean` |
+| `opening` | Slideover is about to be opened — before the transition starts | `Boolean` |
+| `opened` | Slideover was opened — after the transition finishes | `Boolean` |
+| `closing` | Slideover is about to be closed — before the transition starts | `Boolean` |
+| `closed` | Slideover was closed — after the transition finishes | `Boolean` |
 
 :::warning :bulb: A note on closing and open
 The `open` and `close` events are emitted when the slideover is opened or closed, but the `modelValue` is not updated yet.

--- a/packages/vanilla-components/src/components/slideover/slideover.vue
+++ b/packages/vanilla-components/src/components/slideover/slideover.vue
@@ -86,7 +86,15 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['update:modelValue', 'open', 'close'])
+const emit = defineEmits([
+  'update:modelValue',
+  'open',
+  'close',
+  'opening',
+  'opened',
+  'closing',
+  'closed',
+])
 
 const localValue = useVModel(props, 'modelValue')
 const { configuration } = useConfiguration<SlideoverProps>(slideoverConfig, 'Slideover', localValue)
@@ -102,6 +110,8 @@ const open = () => {
     localValue.value = true
     emit('open')
 }
+
+const emitTransitionEvent = (event: 'opening' | 'opened' | 'closing' | 'closed') => emit(event)
 
 const closeOnClickOutside = () => props.closeableOnClickOutside && close()
 
@@ -202,6 +212,10 @@ defineOptions({
   <TransitionRoot
     :show="localValue"
     as="div"
+    @before-enter="emitTransitionEvent('opening')"
+    @after-enter="emitTransitionEvent('opened')"
+    @before-leave="emitTransitionEvent('closing')"
+    @after-leave="emitTransitionEvent('closed')"
   >
     <HeadlessDialog
       :as="as"


### PR DESCRIPTION
As promised, another PR that adds transition events for slideover also. `opening`, `opened`, `closing`, `closed`.