### PR TITLE
[Fix] `useDynamicSlots` does not camelize slot name

### DIFF
--- a/packages/vanilla-components/src/core/use/useDynamicSlots.ts
+++ b/packages/vanilla-components/src/core/use/useDynamicSlots.ts
@@ -1,6 +1,6 @@
-import { camelize } from 'vue'
+import { camelize, capitalize } from 'vue'
 
 export default function useDynamicSlots(prefix: string, slotName: string): string {
   const lowercaseColumnName = slotName.toLowerCase()
-  return camelize(prefix + lowercaseColumnName.charAt(0).toUpperCase() + lowercaseColumnName.slice(1))
+  return camelize(prefix + capitalize(lowercaseColumnName.replace(/\.|\_/g, '-')))
 }


### PR DESCRIPTION
`camelize` function from vue camelizes only words separated by dashes (-), not underscores (_). This PR fixes it by replacing underscores and dots (scoped columns) with dashes.