### PR TITLE
[Fix] Hidden select in rich select

### DIFF
--- a/packages/vanilla-components/src/components/rich-select/rich-select.vue
+++ b/packages/vanilla-components/src/components/rich-select/rich-select.vue
@@ -734,7 +734,7 @@ export default {
           :classes="undefined"
           :multiple="configuration.multiple"
           :options="flattenedOptions"
-          style="width: 0; opacity: 0; height: 0;"
+          style="width: 0; opacity: 0; height: 0; pointer-events: none;"
           aria-hidden="true"
           :disabled="disabled"
           @focusin="rootElementFocusHandler"


### PR DESCRIPTION
Although hidden, the simple select is clickable. Fix by removing pointer events.