### PR TITLE
Allow chevron to be present when :clearable=true and the select is empty

### DIFF
--- a/packages/vanilla-components/src/components/rich-select/partials/trigger.vue
+++ b/packages/vanilla-components/src/components/rich-select/partials/trigger.vue
@@ -53,7 +53,7 @@ const showSelectorIcon = computed((): boolean => {
     return false
   }
 
-  if (!configuration.clearable) {
+  if (!configuration.clearable || !hasSelectedOption) {
     return true
   }
 


### PR DESCRIPTION
This does not address the issue that the rich select has that when the :clearable=false, individual options cannot be deselected. 